### PR TITLE
Update Benchmarks to new DiffEqDevTools

### DIFF
--- a/docs/src/alg_dev/benchmarks.md
+++ b/docs/src/alg_dev/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmark Suite
 
-DiffernetialEquations.jl provides a benchmarking suite to be able to test the
+DifferentialEquations.jl provides a benchmarking suite to be able to test the
 difference in error, speed, and efficiency between algorithms. DifferentialEquations.jl includes current benchmarking notebooks to help users
 understand the performance of the methods. These benchmarking notebooks use the included benchmarking suite. There are two parts to the benchmarking suite: shootouts and work-precision. The `Shootout` tests methods head-to-head for timing and error on the same problem. A `WorkPrecision` draws a work-precision diagram
 for the algorithms in question on the chosen problem.
@@ -24,13 +24,18 @@ which is a dictionary of Symbols to Any, where the symbol is the keyword argumen
 Then you call `Shootout` on that setup. The code is as follows:
 
 ```julia
-tspan = [0,10]
-setups = [Dict(:alg=>:DP5)
-          Dict(:abstol=>1e-3,:reltol=>1e-6,:alg=>:ode45) # Fix ODE to be normal
-          Dict(:alg=>:dopri5)]
-prob = DifferentialEquations.prob_ode_large2Dlinear
+using OrdinaryDiffEq,DiffEqProblemLibrary.ODEProblemLibrary,DiffEqDevTools,ODE,ODEInterface,ODEInterfaceDiffEq
+
+ODEProblemLibrary.importodeproblems()
+prob = ODEProblemLibrary.prob_ode_large2Dlinear
+#define an approxsol to test errors with
+sol = solve(prob,Tsit5(),abstol=1/10^14,reltol=1/10^14)
+
+setups = [Dict(:alg=>DP5())
+          Dict(:abstol=>1e-3,:reltol=>1e-6,:alg=>ode45()) # Fix ODE to be normal
+          Dict(:alg=>dopri5())]
 names = ["DifferentialEquations";"ODE";"ODEInterface"]
-shoot = Shootout(prob,tspan,setups;dt=1/2^(10),names=names)
+shoot = Shootout(prob,setups;names=names)
 ```
 
 Note that keyword arguments applied to `Shootout` are applied to every run, so
@@ -48,7 +53,7 @@ the number of runs used in the time estimate. To be more precise, these function
 by default run the algorithm 20 times on the problem and take the average time.
 This amount can be increased and decreased as needed.
 
-The keyword `appxtrue` allows for specifying a reference against which the error is computed.
+The keyword `appxsol` allows for specifying a reference against which the error is computed.
 The method of error computation can be specified by the keyword `error_estimate` with values `:L2` for the L2 error over the solution time interval, `:l2` calculates the l2 error at the actual steps and the default `:final` only compares the endpoints.
 
 A ShootoutSet is a where you define a vector of probs and tspans and run a shootout

--- a/docs/src/alg_dev/benchmarks.md
+++ b/docs/src/alg_dev/benchmarks.md
@@ -27,10 +27,7 @@ Then you call `Shootout` on that setup. The code is as follows:
 using OrdinaryDiffEq,DiffEqProblemLibrary.ODEProblemLibrary,DiffEqDevTools,ODE,ODEInterface,ODEInterfaceDiffEq
 
 ODEProblemLibrary.importodeproblems()
-prob = ODEProblemLibrary.prob_ode_large2Dlinear
-#define an approxsol to test errors with
-sol = solve(prob,Tsit5(),abstol=1/10^14,reltol=1/10^14)
-
+prob = ODEProblemLibrary.prob_ode_2Dlinear
 setups = [Dict(:alg=>DP5())
           Dict(:abstol=>1e-3,:reltol=>1e-6,:alg=>ode45()) # Fix ODE to be normal
           Dict(:alg=>dopri5())]
@@ -66,9 +63,9 @@ shows how time scales with the user chosen tolerances on a given problem. To mak
 a WorkPrecision, you give it a vector of absolute and relative tolerances:
 
 ```julia
-abstols = 1./10.^(3:10)
-reltols = 1./10.^(3:10)
-wp = WorkPrecision(prob,tspan,abstols,reltols;alg=:DP5,name="Dormand-Prince 4/5")
+abstols = 1 ./10 .^ (3:10)
+reltols = 1 ./10 .^ (3:10)
+wp = WorkPrecision(prob,DP5(),abstols,reltols;name="Dormand-Prince 4/5")
 ```
 
 If we want to plot many WorkPrecisions together in order to compare between
@@ -76,10 +73,10 @@ algorithms, you can make a WorkPrecisionSet. To do so, you pass the setups
 into the function as well:
 
 ```julia
-wp_set = WorkPrecisionSet(prob,tspan,abstols,reltols,setups;dt=1/2^4,numruns=2)
-setups = [Dict(:alg=>:RK4);Dict(:alg=>:Euler);Dict(:alg=>:BS3);
-          Dict(:alg=>:Midpoint);Dict(:alg=>:BS5);Dict(:alg=>:DP5)]
-wp_set = WorkPrecisionSet(prob,tspan,abstols,reltols,setups;dt=1/2^4,numruns=2)
+wp_set = WorkPrecisionSet(prob,tspan,abstols,reltols,setups;numruns=2)
+setups = [Dict(:alg=>RK4());Dict(:alg=>Euler());Dict(:alg=>BS3());
+          Dict(:alg=>Midpoint());Dict(:alg=>BS5());Dict(:alg=>DP5())]    
+wp_set = WorkPrecisionSet(prob,abstols,reltols,setups;dt=1/2^4,numruns=2)
 ```
 
 Both of these types have a plot recipe to produce a work-precision diagram,

--- a/docs/src/alg_dev/benchmarks.md
+++ b/docs/src/alg_dev/benchmarks.md
@@ -32,7 +32,7 @@ setups = [Dict(:alg=>DP5())
           Dict(:abstol=>1e-3,:reltol=>1e-6,:alg=>ode45()) # Fix ODE to be normal
           Dict(:alg=>dopri5())]
 names = ["DifferentialEquations";"ODE";"ODEInterface"]
-shoot = Shootout(prob,setups;names=names)
+shoot = Shootout(prob,setups;dt=1/2^(10),names=names)
 ```
 
 Note that keyword arguments applied to `Shootout` are applied to every run, so


### PR DESCRIPTION
Hi, I was fiddling around with Benchmarks and saw this documentation was not updated to the new build at DiffEqDevTools. MWE:

```
julia> tspan = [0,10]
2-element Array{Int64,1}:
  0
 10

julia> setups = [Dict(:alg=>:DP5)
                 Dict(:abstol=>1e-3,:reltol=>1e-6,:alg=>:ode45) # Fix ODE to be normal
                 Dict(:alg=>:dopri5)]
3-element Array{Dict{Symbol,V} where V,1}:
 Dict(:alg => :DP5)
 Dict{Symbol,Any}(:alg => :ode45,:reltol => 1.0e-6,:abstol => 0.001)
 Dict(:alg => :dopri5)

julia> prob = DifferentialEquations.prob_ode_large2Dlinear
ERROR: UndefVarError: prob_ode_large2Dlinear not defined
Stacktrace:
 [1] getproperty(::Module, ::Symbol) at .\Base.jl:26
 [2] top-level scope at REPL[40]:1

julia> names = ["DifferentialEquations";"ODE";"ODEInterface"]
3-element Array{String,1}:
 "DifferentialEquations"
 "ODE"
 "ODEInterface"

julia> shoot = Shootout(prob,tspan,setups;dt=1/2^(10),names=names)
ERROR: MethodError: no method matching Shootout(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}, ::Array{Dict{Symbol,V} where V,1}; dt=0.0009765625, names=["DifferentialEquations", "ODE", "ODEInterface"])
Closest candidates are:
  Shootout(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:5 got unsupported keyword arguments "dt", "names"
  Shootout(::Array{Dict{Symbol,Any},1}, ::Any, ::Any, ::Any, ::Any, ::Any, ::Array{String,1}, ::Int64, ::Int64, ::String) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:5 got unsupported keyword arguments "dt", "names"
  Shootout(::Any, ::Any; appxsol, names, error_estimate, numruns, seconds, kwargs...) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:31
Stacktrace:
 [1] top-level scope at REPL[42]:1
``` 

```
julia> abstols = 1./10.^(3:10)
ERROR: syntax: invalid syntax "1./"; add space(s) to clarify
Stacktrace:
 [1] top-level scope at REPL[42]:0

julia> reltols = 1./10.^(3:10)
ERROR: syntax: invalid syntax "1./"; add space(s) to clarify
Stacktrace:
 [1] top-level scope at REPL[42]:0

julia> wp = WorkPrecision(prob,tspan,abstols,reltols;alg=:DP5,name="Dormand-Prince 4/5")
ERROR: Inappropiate solve command. The arguments do not make sense. Likely, you gave an algorithm which does not actually exist (or does not `<:DiffEqBase.DEAlgorithm`)
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] __solve(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}; default_set::Bool, second_time::Bool, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:alg, :abstol, :reltol, :timeseries_errors, :dense_errors),Tuple{Symbol,Float64,Float64,Bool,Bool}}}) at C:\Users\Utkarsh\.julia\packages\DiffEqBase\LGnTa\src\solve.jl:278
 [3] solve_call(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}; merge_callbacks::Bool, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:alg, :abstol, :reltol, :timeseries_errors, :dense_errors),Tuple{Symbol,Float64,Float64,Bool,Bool}}}) at C:\Users\Utkarsh\.julia\packages\DiffEqBase\LGnTa\src\solve.jl:96
 [4] solve_up(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Nothing, ::Array{Float64,2}, ::Float64, ::Array{Int64,1}; kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:alg, :abstol, :reltol, :timeseries_errors, :dense_errors),Tuple{Symbol,Float64,Float64,Bool,Bool}}}) at C:\Users\Utkarsh\.julia\packages\DiffEqBase\LGnTa\src\solve.jl:128
 [5] solve(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}; sensealg::Nothing, u0::Nothing, p::Nothing, kwargs::Base.Iterators.Pairs{Symbol,Any,NTuple{5,Symbol},NamedTuple{(:alg, :abstol, :reltol, :timeseries_errors, :dense_errors),Tuple{Symbol,Float64,Float64,Bool,Bool}}}) at C:\Users\Utkarsh\.julia\packages\DiffEqBase\LGnTa\src\solve.jl:106
 [6] WorkPrecision(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}, ::Array{Float64,1}, ::Array{Float64,1}, ::Nothing; name::String, appxsol::Nothing, error_estimate::Symbol, numruns::Int64, seconds::Int64, kwargs::Base.Iterators.Pairs{Symbol,Symbol,Tuple{Symbol},NamedTuple{(:alg,),Tuple{Symbol}}}) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:183
 [7] top-level scope at REPL[45]:1
```

```
julia> wp_set = WorkPrecisionSet(prob,tspan,abstols,reltols,setups;dt=1/2^4,numruns=2)
ERROR: MethodError: no method matching WorkPrecisionSet(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Dict{Symbol,V} where V,1}; dt=0.0625, numruns=2)
Closest candidates are:
  WorkPrecisionSet(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:152 got unsupported keyword arguments "dt", "numruns"
  WorkPrecisionSet(::DiffEqBase.AbstractRODEProblem, ::Any, ::Any, ::Any, ::Any; numruns, numruns_error, print_names, names, appxsol_setup, error_estimate, parallel_type, kwargs...) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:316
  WorkPrecisionSet(::Any, ::Any, ::Any, ::Any; print_names, names, appxsol, error_estimate, test_dt, kwargs...) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:239
  ...
Stacktrace:
 [1] top-level scope at REPL[46]:1

julia> setups = [Dict(:alg=>:RK4);Dict(:alg=>:Euler);Dict(:alg=>:BS3);
                 Dict(:alg=>:Midpoint);Dict(:alg=>:BS5);Dict(:alg=>:DP5)]
6-element Array{Dict{Symbol,Symbol},1}:
 Dict(:alg => :RK4)
 Dict(:alg => :Euler)
 Dict(:alg => :BS3)
 Dict(:alg => :Midpoint)
 Dict(:alg => :BS5)
 Dict(:alg => :DP5)

julia> wp_set = WorkPrecisionSet(prob,tspan,abstols,reltols,setups;dt=1/2^4,numruns=2)
ERROR: MethodError: no method matching WorkPrecisionSet(::ODEProblem{Array{Float64,2},Tuple{Float64,Float64},true,Float64,ODEFunction{true,DiffEqProblemLibrary.ODEProblemLibrary.var"#5#6",LinearAlgebra.UniformScaling{Bool},DiffEqProblemLibrary.ODEProblemLibrary.var"#7#8",Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}},DiffEqBase.StandardODEProblem}, ::Array{Int64,1}, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Dict{Symbol,Symbol},1}; dt=0.0625, numruns=2)
Closest candidates are:
  WorkPrecisionSet(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:152 got unsupported keyword arguments "dt", "numruns"
  WorkPrecisionSet(::DiffEqBase.AbstractRODEProblem, ::Any, ::Any, ::Any, ::Any; numruns, numruns_error, print_names, names, appxsol_setup, error_estimate, parallel_type, kwargs...) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:316
  WorkPrecisionSet(::Any, ::Any, ::Any, ::Any; print_names, names, appxsol, error_estimate, test_dt, kwargs...) at C:\Users\Utkarsh\.julia\packages\DiffEqDevTools\nDVct\src\benchmark.jl:239
  ...
Stacktrace:
 [1] top-level scope at REPL[48]:1
```
@ChrisRackauckas please have a look.