### PR TITLE
updated make.jl to match contemporary template.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,29 @@
-using Documenter,DiffEqDevTools,OrdinaryDiffEq
+using DiffEqDevTools
+using OrdinaryDiffEq
+using Documenter
+
+DocMeta.setdocmeta!(DiffEqDevTools, :DocTestSetup, :(using DiffEqDevTools); recursive = true)
 
 include("pages.jl")
 
-makedocs(modules=[DiffEqDevTools,OrdinaryDiffEq],
-         doctest=false, clean=true,
-         format = Documenter.HTML(),
-         sitename="SciML Developer Documentation",
-         authors="Chris Rackauckas",
+makedocs(sitename = "SciML Developer Documentation",
+         authors = "Chris Rackauckas",
+         modules = [DiffEqDevTools,OrdinaryDiffEq],
+         clean = true, doctest = false,
+         strict = [
+             :doctest,
+             :linkcheck,
+             :parse_error,
+             :example_block,
+             # Other available options are
+             # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
+         ],
+         format = Documenter.HTML(analytics = "UA-90474609-3",
+                                  assets = ["assets/favicon.ico"],
+                                  canonical = "https://docs.sciml.ai/DiffEqDevDocs/stable/"),
          pages = pages)
 
-deploydocs(
-   repo = "github.com/SciML/DiffEqDevDocs.jl.git",
-)
+deploydocs(;
+           repo = "github.com/SciML/DiffEqDevDocs.jl",
+           devbranch = "master")
+


### PR DESCRIPTION
I updated `make.jl` to the more modern template, based upon `LinearSolve`. I tested the build locally and (1) the build completed successfully, (2) the links worked.

