### PR TITLE
Changed name of README docs badge from `dev` to `Global Docs`, as per convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DiffEqDevDocs
 
 [![Join the chat at https://gitter.im/JuliaDiffEq/Lobby](https://badges.gitter.im/JuliaDiffEq/Lobby.svg)](https://gitter.im/JuliaDiffEq/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://devdocs.sciml.ai/stable/)
+[![Global Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://devdocs.sciml.ai/stable/)
 
 DiffEqDevDocs.jl is a component package in the DifferentialEquations ecosystem. It holds [the developer documentation for the solvers and add-on packages](https://devdocs.sciml.ai/dev/).
 Users interested to the ecosystem should refer to this as a guide.


### PR DESCRIPTION
changed the name on the badge from  to  to match the sciml docs convention.