### PR TITLE
Use the correct name for Heun's method

### DIFF
--- a/docs/src/internals/tableaus.md
+++ b/docs/src/internals/tableaus.md
@@ -3,7 +3,7 @@
 ### Explicit Runge-Kutta Methods
 
 * `constructEuler` - Euler's 1st order method.
-* `constructHuen()` Huen's order 2 method.
+* `constructHeun()` Heun's order 2 method.
 * `constructRalston()` - Ralston's order 2 method.
 * `constructSSPRK22()` - Explicit SSP method of order 2 using 2 stages.
 * `constructKutta3` - Kutta's classic 3rd order method.


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [ScioML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I don't know anything about the checklist above, but I'm certain that it is called `Heun's method` and I have checked that it is written like that in https://github.com/SciML/DiffEqDevTools.jl/blob/master/src/ode_tableaus.jl. I hope this is enough to get this PR merged, even though I haven't checked any of the bullet points above.
